### PR TITLE
Restart background service on failure

### DIFF
--- a/strava-heatmap-proxy.service
+++ b/strava-heatmap-proxy.service
@@ -1,9 +1,14 @@
 [Unit]
 Description=Proxy server for accessing the Strava Global Heatmap
+StartLimitBurst=3
+StartLimitIntervalSec=30
 
 [Service]
 Environment="STRAVA_HEATMAP_PROXY_PORT=9192"
 ExecStart=%h/.local/bin/strava-heatmap-proxy --port ${STRAVA_HEATMAP_PROXY_PORT} --allow-origins '["https://gpx.studio"]' --no-init
+Restart=on-failure
+RestartSec=5
+
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
The other day, my background service failed with the following logs, seems like IPv6 is not supported in the network I was connected to at that time. A simple restart of the service helped, IPv4 was used that time.

```
Nov 27 15:17:31 thinkpat systemd[1465]: Started Proxy server for accessing the Strava Global Heatmap.
Nov 27 15:17:31 thinkpat strava-heatmap-proxy[1497]: 2025/11/27 15:17:31 CloudFront cookies from file will expire at 2025-08-15 19:16:15 +0200 CEST
Nov 27 15:17:31 thinkpat strava-heatmap-proxy[1497]: 2025/11/27 15:17:31 Started proxy for target https://content-a.strava.com/ on http://localhost:9192/ ..
Nov 27 16:35:36 thinkpat strava-heatmap-proxy[1497]: 2025/11/27 16:35:36 CloudFront cookies have expired, refreshing...
Nov 27 16:35:36 thinkpat strava-heatmap-proxy[1497]: 2025/11/27 16:35:36 CloudFront cookies have expired, refreshing...
Nov 27 16:35:36 thinkpat strava-heatmap-proxy[1497]: 2025/11/27 16:35:36 CloudFront cookies have expired, refreshing...
Nov 27 16:35:46 thinkpat strava-heatmap-proxy[1497]: 2025/11/27 16:35:46 Warning: Failed to fetch CloudFront cookies: failed to perform request: Head "https://www.strava.com/maps": dial tcp [--- some ipv6 address was here ---]:443: connect: network is unreachable
Nov 27 16:35:46 thinkpat systemd[1465]: strava-heatmap-proxy.service: Main process exited, code=exited, status=1/FAILURE
Nov 27 16:35:46 thinkpat systemd[1465]: strava-heatmap-proxy.service: Failed with result 'exit-code'.
```

In order to automatically recover from similar failures, this PR activates restart on-failure logic in the systemd service file.