### PR TITLE
Filter out empty CloudFront cookies

### DIFF
--- a/strava-heatmap-proxy.go
+++ b/strava-heatmap-proxy.go
@@ -158,7 +158,9 @@ func (c *StravaSessionClient) fetchCloudFrontCookies() error {
 	for _, cookie := range resp.Cookies() {
 		switch cookie.Name {
 		case "CloudFront-Signature", "CloudFront-Policy", "CloudFront-Key-Pair-Id", "_strava_idcf":
-			cookies = append(cookies, cookie)
+			if cookie.Value != "" {
+            	cookies = append(cookies, cookie)
+            }
 		case "_strava_CloudFront-Expires":
 			expiration, err = strconv.ParseInt(cookie.Value, 10, 64)
 			if err != nil {


### PR DESCRIPTION
When fetching Cloudfront cookies renewal, Strava answer with 2 sets of cookies : one with empty value and Max-age=-1 (to supress old cookies) then the new ones. This script keep the 8 cookies and use probably the empty ones. Resulting a MissingKey error in the web browser. Proposal to filter empty Cloudfront cookies.