### PR TITLE
Add arm64 build and docker-compose

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,11 +15,13 @@ jobs:
       - name: Check code format
         run: make -C strava-heatmap-proxy formatcheck
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: strava-heatmap-proxy/
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: docker/setup-qemu-action@v3
+
       - uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
@@ -25,7 +27,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: strava-heatmap-proxy/
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/strava-heatmap-proxy:latest

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ LOCAL_PORT=8080
 docker run --rm -p ${LOCAL_PORT}:8080 -v ${HOME}/.config/strava-heatmap-proxy:/home/nonroot/.config/strava-heatmap-proxy:ro docker.io/patrickziegler/strava-heatmap-proxy:latest
 ```
 
+Alternatively, use the provided [docker-compose.yml](docker-compose.yml) for a one-command start:
+
+```sh
+docker compose up -d
+```
+
 This will set up a local proxy server for `https://content-a.strava.com/`.
 Every request to `http://localhost:8080/` will then be extended with session cookies before being forwarded to Strava.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  strava-heatmap-proxy:
+    image: patrickziegler/strava-heatmap-proxy:latest
+    container_name: strava-heatmap-proxy
+    restart: unless-stopped
+    ports:
+      - "${LOCAL_PORT:-8080}:8080"
+    volumes:
+      - ${HOME}/.config/strava-heatmap-proxy:/home/nonroot/.config/strava-heatmap-proxy:ro


### PR DESCRIPTION
- Publish multi-arch (amd64 + arm64) Docker images so Apple Silicon and Raspberry Pi users can pull :latest directly.
- Add docker-compose.yml for one-command start.